### PR TITLE
fixed fatal error if notifications are disabled

### DIFF
--- a/public/classes/class-buddy-views-integration.php
+++ b/public/classes/class-buddy-views-integration.php
@@ -100,7 +100,7 @@ if( !class_exists( 'Buddy_Views_Integration' ) ) {
          * @param $args
          */
         public function add_notification( $args ) {
-            $notification_id = bp_notifications_add_notification( $args );
+            if(function_exists("bp_notifications_add_notification")) $notification_id = bp_notifications_add_notification( $args );
         }
 
         /**


### PR DESCRIPTION
If notifications are disabled you get this error:
AH01215: PHP Fatal error: Call to undefined function bp_notifications_add_notification() in wp-content/plugins/buddy-views/public/classes/class-buddy-views-integration.php on line 103
